### PR TITLE
fix: make gha-badge point at the right repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SNT Staking contracts [![Github Actions][gha-badge]][gha] [![Foundry][foundry-badge]][foundry]
 
-[gha]: https://github.com/vacp2p/foundry-template/actions
-[gha-badge]: https://github.com/vacp2p/foundry-template/actions/workflows/ci.yml/badge.svg
+[gha]: https://github.com/logos-co/staking/actions
+[gha-badge]: https://github.com/logos-co/staking/actions/workflows/ci.yml/badge.svg
 [foundry]: https://getfoundry.sh/
 [foundry-badge]: https://img.shields.io/badge/Built%20with-Foundry-FFDB1C.svg
 


### PR DESCRIPTION
## Description

This was a left over from migrating to the foundry template.


## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [x] Ran `pnpm lint`?
- [ ] Ran `forge test`?
