### PR TITLE
docs: fix PR template to mention `pnpm` not `yarn`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,5 +8,5 @@ Ensure you completed **all of the steps** below before submitting your pull requ
 
 - [ ] Added natspec comments?
 - [ ] Ran `forge snapshot`?
-- [ ] Ran `yarn lint`?
+- [ ] Ran `pnpm lint`?
 - [ ] Ran `forge test`?


### PR DESCRIPTION
This has been fixed in the original foundry template as well but wasn't yet in the changes done to this repository.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [x] Ran `pnpm lint`?
- [ ] Ran `forge test`?
