### PR TITLE
fix(remappings): add trailing slash to OZ remapping

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,2 +1,2 @@
 forge-std/=lib/forge-std/src/
-@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts
+@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/


### PR DESCRIPTION
Even though import lookup during compilation works fine without it, language servers get confused and expect the trailing slash.


## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [ ] Ran `pnpm lint`?
- [x] Ran `forge test`?
