### PR TITLE
test(StakeManager): add test to check that inital MPs are minted

### DIFF
--- a/contracts/StakeManager.sol
+++ b/contracts/StakeManager.sol
@@ -38,9 +38,9 @@ contract StakeManager is Ownable {
     uint256 public constant MP_APY = 1;
     uint256 public constant MAX_BOOST = 4;
 
-    mapping(address => Account) accounts;
+    mapping(address => Account) public accounts;
     mapping(uint256 => Epoch) epochs;
-    mapping(bytes32 => bool) isVault;
+    mapping(bytes32 => bool) public isVault;
 
     uint256 public currentEpoch;
     uint256 public pendingReward;


### PR DESCRIPTION
This adds a test that ensures multiplier points are minted with a 1:1 ratio to the stake token amount.

This scenario covers the case where no lock up time is set during staking.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [x] Ran `pnpm lint`?
- [x] Ran `forge test`?
- [ ] Ran `pnpm verify`?
