### PR TITLE
chore(workflows): add-pr-to-project-board only trigger on `opened`

### DIFF
--- a/.github/workflows/add-pr-to-project-board.yml
+++ b/.github/workflows/add-pr-to-project-board.yml
@@ -2,6 +2,8 @@ name: Add PR to task board
 
 on:
   pull_request:
+    types:
+      - opened
 
 jobs:
   add-to-project:


### PR DESCRIPTION
This is to avoid getting these failing CI tasks where adding a PR to the board fails when it was already added before (happens when pushing into an existing PR).


## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [x] Ran `pnpm lint`?
- [ ] Ran `forge test`?
- [ ] Ran `pnpm verify`?
