### PR TITLE
feat(script): add deployment script for new `StakeManager`s

### DIFF
--- a/script/DeployMigrationStakeManager.s.sol
+++ b/script/DeployMigrationStakeManager.s.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <=0.9.0;
+
+import { BaseScript } from "./Base.s.sol";
+import { StakeManager } from "../contracts/StakeManager.sol";
+
+contract DeployMigrationStakeManager is BaseScript {
+    error DeployMigrationStakeManager_InvalidStakeTokenAddress();
+
+    address public prevStakeManager;
+
+    address public stakeToken;
+
+    constructor(address _prevStakeManager, address _stakeToken) {
+        prevStakeManager = _prevStakeManager;
+        stakeToken = _stakeToken;
+    }
+
+    function run() public returns (StakeManager) {
+        prevStakeManager = vm.envOr({ name: "PREV_STAKE_MANAGER", defaultValue: prevStakeManager });
+        stakeToken = vm.envOr({ name: "STAKE_TOKEN_ADDRESS", defaultValue: stakeToken });
+
+        if (stakeToken == address(0)) {
+            revert DeployMigrationStakeManager_InvalidStakeTokenAddress();
+        }
+
+        vm.startBroadcast(broadcaster);
+        StakeManager stakeManager = new StakeManager(stakeToken, prevStakeManager);
+        vm.stopBroadcast();
+
+        return stakeManager;
+    }
+}

--- a/test/StakeManager.t.sol
+++ b/test/StakeManager.t.sol
@@ -5,6 +5,7 @@ import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 import { Test, console } from "forge-std/Test.sol";
 import { Deploy } from "../script/Deploy.s.sol";
+import { DeployMigrationStakeManager } from "../script/DeployMigrationStakeManager.s.sol";
 import { DeploymentConfig } from "../script/DeploymentConfig.s.sol";
 import { StakeManager } from "../contracts/StakeManager.sol";
 import { StakeVault } from "../contracts/StakeVault.sol";
@@ -428,5 +429,26 @@ contract UserFlowsTest is StakeManagerTest {
         userVault.unstake(100);
         assertEq(ERC20(stakeToken).balanceOf(address(userVault)), 0);
         assertEq(stakeManager.totalSupplyBalance(), 0);
+    }
+}
+
+contract DeployMigrationStakeManagerTest is StakeManagerTest {
+    StakeManager internal newStakeManager;
+
+    function setUp() public virtual override {
+        super.setUp();
+        DeployMigrationStakeManager deployment = new DeployMigrationStakeManager(address(stakeManager), stakeToken);
+        newStakeManager = deployment.run();
+    }
+
+    function testNewDeployment() public {
+        assertEq(newStakeManager.owner(), deployer);
+        assertEq(newStakeManager.currentEpoch(), 0);
+        assertEq(newStakeManager.pendingReward(), 0);
+        assertEq(newStakeManager.totalSupplyMP(), 0);
+        assertEq(newStakeManager.totalSupplyBalance(), 0);
+        assertEq(address(newStakeManager.stakedToken()), stakeToken);
+        assertEq(address(newStakeManager.oldManager()), address(stakeManager));
+        assertEq(newStakeManager.totalSupply(), 0);
     }
 }


### PR DESCRIPTION
This is needed to deploy individual new `StakeManager` instances in both, production environment and testing.

The script can be used as follows:

Within tests, to get a new `StakeManager` instance that has a reference to an older `StakeManager` instance, run:

```solidity
function setUp() public virtual override {
    super.setUp();
    DeployMigrationStakeManager deployment = new DeployMigrationStakeManager(address(stakeManager), stakeToken);
    newStakeManager = deployment.run();
}
```

Where `address(stakeManager)` is the address of the current `StakeManager` and `stakeToken` is the address of the stake token.

To deploy a new instance from the CLI using `forge`, one can make use of the `PREV_STAKE_MANAGER` and `STAKE_TOKEN_ADDRESS` environment variables like this:

```sh
$ PREV_STAKE_MANAGER=0x123 STAKE_TOKEN_ADDRES=0x456 forge script script/DeployMigrationStakeManager.s.sol
```

The script will revert when `STAKE_TOKEN_ADDRESS` is `address(0)`.

Closes #71


## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [ ] Ran `pnpm gas-report`?
- [x] Ran `pnpm lint`?
- [x] Ran `forge test`?
- [ ] Ran `pnpm verify`?
