### PR TITLE
chore(Certora specs): comment out purposefully failing rule

### DIFF
--- a/certora/specs/StakeManager.spec
+++ b/certora/specs/StakeManager.spec
@@ -107,15 +107,18 @@ rule revertsWhenNoMigration(method f) {
   assert isMigrationfunction(f) => reverted;
 }
 
-rule whoChangeERC20Balance(  method f ) filtered { f -> f.contract != staked }
-{
-  address user;
-  uint256 before = staked.balanceOf(user);
-  calldataarg args;
-  env e;
-  f(e,args);
-  assert before == staked.balanceOf(user);
-}
+// This rule is commented out as it's just a helper rule to easily see which
+// functions change the balance of the `StakeManager` contract.
+//
+// rule whoChangeERC20Balance(  method f ) filtered { f -> f.contract != staked }
+// {
+//   address user;
+//   uint256 before = staked.balanceOf(user);
+//   calldataarg args;
+//   env e;
+//   f(e,args);
+//   assert before == staked.balanceOf(user);
+// }
 
 rule epochOnlyIncreases {
   method f;


### PR DESCRIPTION
We've introduced a rule that finds counter examples for all functions that changes balances. This rule will always fail by definition, so we're commenting it out to get CI green again.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [ ] Ran `pnpm gas-report`?
- [ ] Ran `pnpm lint`?
- [ ] Ran `forge test`?
- [x] Ran `pnpm verify`?
