### PR TITLE
fix(Certora specs): ensure prover runs rules on `currentContract`

### DIFF
--- a/certora/specs/StakeManagerStartMigration.spec
+++ b/certora/specs/StakeManagerStartMigration.spec
@@ -41,7 +41,7 @@ definition blockedWhenNotMigrating(method f) returns bool = (
       );
 
 rule rejectWhenMigrating(method f) filtered {
-  f -> blockedWhenMigrating(f)
+  f -> blockedWhenMigrating(f) && f.contract == currentContract
 } {
   calldataarg args;
   env e;
@@ -68,7 +68,7 @@ rule allowWhenMigrating(method f) filtered {
 
 
 rule rejectWhenNotMigrating(method f) filtered {
-  f -> blockedWhenNotMigrating(f)
+  f -> blockedWhenNotMigrating(f) && f.contract == currentContract
 } {
   calldataarg args;
   env e;
@@ -103,8 +103,9 @@ rule startMigrationCorrect {
   assert newStakeManager.totalSupplyBalance() == currentContract.totalSupplyBalance();
 }
 
-rule migrationLockedIn {
-  method f;
+rule migrationLockedIn(method f) filtered {
+  f -> !blockedWhenMigrating(f) && f.contract == currentContract
+} {
   env e;
   calldataarg args;
 


### PR DESCRIPTION
Since we're implementing rules for `StakeManager` migrations, we need multiple instances inside the certora specs.

This results in the prover trying to run rules on the other `StakeManager` instance as well, which isn't always desired, as it causes some rules to fail, even though they'd pass if they'd be executed only on the `currentContract`.

This commit makes the filter condition for relevant rules stronger, such that the prover will not run them on the `newStakeManager` contract instance.


## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [ ] Ran `pnpm gas-report`?
- [ ] Ran `pnpm lint`?
- [ ] Ran `forge test`?
- [x] Ran `pnpm verify`?
