### PR TITLE
fix(StakeManager): don't allow migration initialization while migrating

### DIFF
--- a/certora/specs/StakeManagerStartMigration.spec
+++ b/certora/specs/StakeManagerStartMigration.spec
@@ -32,7 +32,8 @@ definition blockedWhenMigrating(method f) returns bool = (
       f.selector == sig:unstake(uint256).selector ||
       f.selector == sig:lock(uint256).selector ||
       f.selector == sig:executeEpoch().selector ||
-      f.selector == sig:startMigration(address).selector
+      f.selector == sig:startMigration(address).selector ||
+      f.selector == sig:migrationInitialize(uint256,uint256,uint256,uint256).selector
       );
 
 definition blockedWhenNotMigrating(method f) returns bool = (
@@ -116,8 +117,9 @@ rule migrationLockedIn(method f) filtered {
   assert currentContract.migration != 0;
 }
 
-rule epochStaysSameOnMigration {
-  method f;
+rule epochStaysSameOnMigration(method f) filtered {
+  f -> !blockedWhenMigrating(f) && f.contract == currentContract
+} {
   env e;
   calldataarg args;
 

--- a/contracts/StakeManager.sol
+++ b/contracts/StakeManager.sol
@@ -251,6 +251,9 @@ contract StakeManager is Ownable {
         external
         onlyOldManager
     {
+        if (address(migration) != address(0)) {
+            revert StakeManager__PendingMigration();
+        }
         currentEpoch = _currentEpoch;
         totalSupplyMP = _totalSupplyMP;
         totalSupplyBalance = _totalSupplyBalance;


### PR DESCRIPTION
This is actually a bug that the certora prover found. The rule `epochStaysSameOnMigration` failed because a previous `StakeManager` could call `migrationInitialize` and change `currentEpoch` on a next `StakeManager`, even though the next `StakeManager` might be in migration itself (which means the `currentEpoch` is now allowed to change).

This commit fixes this by ensure `migrationInitialize()` will revert if the `StakeManager` already has a `migration` on going.


## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [ ] Ran `pnpm gas-report`?
- [ ] Ran `pnpm lint`?
- [ ] Ran `forge test`?
- [x] Ran `pnpm verify`?
