### PR TITLE
fix(StakeManager): initial MP should not increase when locking

### DIFF
--- a/certora/specs/StakeManager.spec
+++ b/certora/specs/StakeManager.spec
@@ -193,6 +193,26 @@ rule stakingGreaterLockupTimeMeansGreaterMPs {
   satisfy to_mathint(multiplierPointsAfter1) > to_mathint(multiplierPointsAfter2);
 }
 
+rule increasingLockupTimeNeverIncreasesInitialMPs {
+
+    env e;
+    uint256 amount;
+    uint256 lockupTime1;
+    uint256 lockupTime2;
+    uint256 multiplierPointsAfter1;
+    uint256 multiplierPointsAfter2;
+
+    storage initalStorage = lastStorage;
+
+    stake(e, amount, lockupTime1);
+    multiplierPointsAfter1 = getAccountInitialMultiplierPoints(e.msg.sender);
+
+    lock(e, lockupTime2);
+    multiplierPointsAfter2 = getAccountInitialMultiplierPoints(e.msg.sender);
+
+    assert to_mathint(multiplierPointsAfter1) == to_mathint(multiplierPointsAfter2);
+}
+
 /**
 @title when there is no migration - some functions must revert.
 Other function should have non reverting cases

--- a/certora/specs/StakeManager.spec
+++ b/certora/specs/StakeManager.spec
@@ -3,9 +3,9 @@ methods {
   function staked.balanceOf(address) external returns (uint256) envfree;
   function totalSupplyBalance() external returns (uint256) envfree;
   function totalSupplyMP() external returns (uint256) envfree;
-  function oldManager() external returns (address) envfree;
+  function previousManager() external returns (address) envfree;
   function _.migrateFrom(address, bool, StakeManager.Account) external => NONDET;
-  function _.increaseMPFromMigration(uint256) external => NONDET;
+  function _.increaseTotalMP(uint256) external => NONDET;
   function _.migrationInitialize(uint256,uint256,uint256,uint256) external => NONDET;
   function accounts(address) external returns(address, uint256, uint256, uint256, uint256, uint256, uint256) envfree;
   function Math.mulDiv(uint256 a, uint256 b, uint256 c) internal returns uint256 => mulDivSummary(a,b,c);
@@ -54,14 +54,14 @@ function isMigrationfunction(method f) returns bool {
  cases where it is zero. specifically no externall call to the migration contract */
 function simplification(env e) {
   require currentContract.migration == 0;
-  require currentContract.oldManager() == 0;
+  require currentContract.previousManager() == 0;
   require e.msg.sender != 0;
 }
 
 definition requiresPreviousManager(method f) returns bool = (
   f.selector == sig:migrationInitialize(uint256,uint256,uint256,uint256).selector ||
   f.selector == sig:migrateFrom(address,bool,StakeManager.Account).selector ||
-  f.selector == sig:increaseMPFromMigration(uint256).selector
+  f.selector == sig:increaseTotalMP(uint256).selector
   );
 
 definition requiresNextManager(method f) returns bool = (

--- a/certora/specs/StakeManagerProcessAccount.spec
+++ b/certora/specs/StakeManagerProcessAccount.spec
@@ -31,7 +31,7 @@ hook Sstore accounts[KEY address addr].balance uint256 newValue (uint256 oldValu
 definition requiresPreviousManager(method f) returns bool = (
   f.selector == sig:migrationInitialize(uint256,uint256,uint256,uint256).selector ||
   f.selector == sig:migrateFrom(address,bool,StakeManager.Account).selector ||
-  f.selector == sig:increaseMPFromMigration(uint256).selector
+  f.selector == sig:increaseTotalMP(uint256).selector
   );
 
 definition requiresNextManager(method f) returns bool = (

--- a/certora/specs/StakeManagerStartMigration.spec
+++ b/certora/specs/StakeManagerStartMigration.spec
@@ -5,7 +5,7 @@ methods {
   function staked.balanceOf(address) external returns (uint256) envfree;
   function totalSupplyBalance() external returns (uint256) envfree;
   function totalSupplyMP() external returns (uint256) envfree;
-  function oldManager() external returns (address) envfree;
+  function previousManager() external returns (address) envfree;
   function accounts(address) external returns(address, uint256, uint256, uint256, uint256, uint256, uint256) envfree;
 
   function _.migrationInitialize(uint256,uint256,uint256,uint256) external => DISPATCHER(true);

--- a/certora/specs/StakeVault.spec
+++ b/certora/specs/StakeVault.spec
@@ -7,7 +7,7 @@ methods {
   function ERC20A.totalSupply() external returns(uint256) envfree;
   function StakeManager.accounts(address) external returns(address, uint256, uint256, uint256, uint256, uint256, uint256) envfree;
   function _.migrateFrom(address, bool, StakeManager.Account) external => DISPATCHER(true);
-  function _.increaseMPFromMigration(uint256) external => DISPATCHER(true);
+  function _.increaseTotalMP(uint256) external => DISPATCHER(true);
   function _.owner() external => DISPATCHER(true);
   function Math.mulDiv(uint256 a, uint256 b, uint256 c) internal returns uint256 => mulDivSummary(a,b,c);
 }
@@ -27,7 +27,7 @@ function getAccountBalance(address addr) returns uint256 {
 definition isMigrationFunction(method f) returns bool = (
   f.selector == sig:stakeManager.migrationInitialize(uint256,uint256,uint256,uint256).selector ||
   f.selector == sig:stakeManager.migrateFrom(address,bool,StakeManager.Account).selector ||
-  f.selector == sig:stakeManager.increaseMPFromMigration(uint256).selector ||
+  f.selector == sig:stakeManager.increaseTotalMP(uint256).selector ||
   f.selector == sig:stakeManager.startMigration(address).selector
   );
 

--- a/contracts/StakeManager.sol
+++ b/contracts/StakeManager.sol
@@ -222,9 +222,15 @@ contract StakeManager is Ownable {
         if (deltaTime < MIN_LOCKUP_PERIOD || deltaTime > MAX_LOCKUP_PERIOD) {
             revert StakeManager__InvalidLockTime();
         }
-        _mintInitialMP(account, _timeToIncrease, 0);
-        //update account storage
+
+        uint256 mpToMint = _getMaxMPToMint(
+            _getMPToMint(account.balance, _timeToIncrease), account.balance, account.initialMP, account.currentMP
+        );
+
+        totalSupplyMP += mpToMint;
+        account.currentMP += mpToMint;
         account.lockUntil = lockUntil;
+        account.lastMint = block.timestamp;
     }
 
     /**
@@ -433,9 +439,9 @@ contract StakeManager is Ownable {
         );
 
         //update storage
-        account.lastMint = processTime;
-        account.currentMP += increasedMP;
         totalSupplyMP += increasedMP;
+        account.currentMP += increasedMP;
+        account.lastMint = processTime;
         epoch.totalSupply += increasedMP;
     }
 

--- a/test/StakeManager.t.sol
+++ b/test/StakeManager.t.sol
@@ -413,23 +413,13 @@ contract LockTest is StakeManagerTest {
         userVault.lock(minLockup - 1);
     }
 
-    function test_ShouldIncreaseInitialMP() public {
-        uint256 stakeAmount = 100;
-        uint256 lockTime = stakeManager.MAX_LOCKUP_PERIOD();
-        StakeVault userVault = _createStakingAccount(testUser, stakeAmount);
-        (, uint256 balance, uint256 initialMP, uint256 currentMP,,,) = stakeManager.accounts(address(userVault));
-        uint256 totalSupplyMPBefore = stakeManager.totalSupplyMP();
-
+    function test_InitialMPDoesNotIncreaseAfterLock() public {
+        uint256 minLockup = stakeManager.MIN_LOCKUP_PERIOD();
+        StakeVault userVault = _createStakingAccount(testUser, 1000, 0, 1000);
         vm.startPrank(testUser);
-        userVault.lock(lockTime);
-
-        (, uint256 newBalance, uint256 newInitialMP, uint256 newCurrentMP,,,) =
-            stakeManager.accounts(address(userVault));
-        uint256 totalSupplyMPAfter = stakeManager.totalSupplyMP();
-        assertGt(totalSupplyMPAfter, totalSupplyMPBefore, "totalSupplyMP");
-        assertGt(newInitialMP, initialMP, "initialMP");
-        assertGt(newCurrentMP, currentMP, "currentMP");
-        assertEq(newBalance, balance, "balance");
+        userVault.lock(minLockup);
+        (, uint256 balance, uint256 initialMP,,,,) = stakeManager.accounts(address(userVault));
+        assertEq(initialMP, balance);
     }
 }
 

--- a/test/StakeManager.t.sol
+++ b/test/StakeManager.t.sol
@@ -34,7 +34,7 @@ contract StakeManagerTest is Test {
         assertEq(stakeManager.totalSupplyMP(), 0);
         assertEq(stakeManager.totalSupplyBalance(), 0);
         assertEq(address(stakeManager.stakedToken()), stakeToken);
-        assertEq(address(stakeManager.oldManager()), address(0));
+        assertEq(address(stakeManager.previousManager()), address(0));
         assertEq(stakeManager.totalSupply(), 0);
     }
 
@@ -183,7 +183,6 @@ contract StakeTest is StakeManagerTest {
     function test_restakeJustLock() public {
         uint256 lockToIncrease = stakeManager.MIN_LOCKUP_PERIOD();
         uint256 stakeAmount = 100;
-        uint256 stakeAmount2 = 50;
         uint256 mintAmount = stakeAmount * 10;
         StakeVault userVault = _createStakingAccount(testUser, stakeAmount, 0, mintAmount);
         StakeVault userVault2 = _createStakingAccount(testUser2, stakeAmount, lockToIncrease, mintAmount);
@@ -629,27 +628,6 @@ contract ExecuteAccountTest is StakeManagerTest {
         }
     }
 
-    function internal_logAccount(address vault) internal {
-        (
-            address rewardAddress,
-            uint256 balance,
-            uint256 initialMP,
-            uint256 currentMP,
-            uint256 lastMint,
-            uint256 lockUntil,
-            uint256 epoch
-        ) = stakeManager.accounts(vault);
-        console.log("===============");
-        console.log("rewardAddress :", rewardAddress);
-        console.log("##### balance :", balance);
-        console.log("### initialMP :", initialMP);
-        console.log("### currentMP :", currentMP);
-        console.log("#### lastMint :", lastMint);
-        console.log("### lockUntil :", lockUntil);
-        console.log("####### epoch :", epoch);
-        console.log("===============");
-    }
-
     function test_UpdateEpoch() public { }
     function test_PayRewards() public { }
 
@@ -716,7 +694,7 @@ contract MigrationStakeManagerTest is StakeManagerTest {
         assertEq(newStakeManager.totalSupplyMP(), 0);
         assertEq(newStakeManager.totalSupplyBalance(), 0);
         assertEq(address(newStakeManager.stakedToken()), stakeToken);
-        assertEq(address(newStakeManager.oldManager()), address(stakeManager));
+        assertEq(address(newStakeManager.previousManager()), address(stakeManager));
         assertEq(newStakeManager.totalSupply(), 0);
     }
 


### PR DESCRIPTION
When an account calls `lock()` on the `StakeManager` it ultimately
called `_mintInitialMP()` which besides increasing the accounts
`currentMP`, it also increases the accounts `initialMP`.

This seems incorrect, as `initialMP` should only increase at first
stake.

Also, notice how inside `lock()` it always passes an `amount` of `0` to
to `_mintInitialMP()`, so it only ever uses one code path of that
function.

This commit adjust `lock()` such that it no longer uses
`_mintInitialMP()`. Instead it makes use of `_getMaxMPToMint` based on
the lock up time delta.

It also removes a test that claims that `initialMP` should increase on
`lock()` and instead adds a test an a CVL rule ensure `initialMP`
doesn't increase when locking.



## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [ ] Ran `pnpm gas-report`?
- [x] Ran `pnpm lint`?
- [x] Ran `forge test`?
- [x] Ran `pnpm verify`?
