### PR TITLE
refactor(StakeManager): initialMP -> bonusMP, currentMP -> totalMP

### DIFF
--- a/test/StakeManager.t.sol
+++ b/test/StakeManager.t.sol
@@ -108,16 +108,16 @@ contract StakeTest is StakeManagerTest {
         uint256 stakeAmount = 100;
         StakeVault userVault = _createStakingAccount(testUser, stakeAmount, 0, stakeAmount * 10);
 
-        (,, uint256 currentMP,,,,) = stakeManager.accounts(address(userVault));
+        (,, uint256 totalMP,,,,) = stakeManager.accounts(address(userVault));
         assertEq(stakeManager.totalSupplyMP(), stakeAmount, "total multiplier point supply");
-        assertEq(currentMP, stakeAmount, "user multiplier points");
+        assertEq(totalMP, stakeAmount, "user multiplier points");
 
         vm.prank(testUser);
         userVault.unstake(stakeAmount);
 
-        (,,, currentMP,,,) = stakeManager.accounts(address(userVault));
+        (,,, totalMP,,,) = stakeManager.accounts(address(userVault));
         assertEq(stakeManager.totalSupplyMP(), 0, "totalSupplyMP burned after unstaking");
-        assertEq(currentMP, 0, "userMP burned after unstaking");
+        assertEq(totalMP, 0, "userMP burned after unstaking");
     }
 
     function test_restakeOnLocked() public {
@@ -131,18 +131,18 @@ contract StakeTest is StakeManagerTest {
         vm.prank(testUser);
         userVault.stake(stakeAmount2, 0);
 
-        (, uint256 balance,, uint256 currentMP,,,) = stakeManager.accounts(address(userVault));
+        (, uint256 balance,, uint256 totalMP,,,) = stakeManager.accounts(address(userVault));
         assertEq(balance, stakeAmount + stakeAmount2, "account balance");
-        assertGt(currentMP, stakeAmount + stakeAmount2, "account MP");
+        assertGt(totalMP, stakeAmount + stakeAmount2, "account MP");
 
         vm.warp(stakeManager.epochEnd());
 
         vm.prank(testUser);
         userVault.stake(stakeAmount3, 0);
 
-        (, balance,, currentMP,,,) = stakeManager.accounts(address(userVault));
+        (, balance,, totalMP,,,) = stakeManager.accounts(address(userVault));
         assertEq(balance, stakeAmount + stakeAmount2 + stakeAmount3, "account balance 2");
-        assertGt(currentMP, stakeAmount + stakeAmount2 + stakeAmount3, "account MP 2");
+        assertGt(totalMP, stakeAmount + stakeAmount2 + stakeAmount3, "account MP 2");
     }
 
     function test_restakeJustStake() public {
@@ -158,12 +158,12 @@ contract StakeTest is StakeManagerTest {
         vm.prank(testUser2);
         userVault2.stake(stakeAmount2, 0);
 
-        (, uint256 balance,, uint256 currentMP,,,) = stakeManager.accounts(address(userVault));
+        (, uint256 balance,, uint256 totalMP,,,) = stakeManager.accounts(address(userVault));
         assertEq(balance, stakeAmount + stakeAmount2, "account balance");
-        assertEq(currentMP, stakeAmount + stakeAmount2, "account MP");
-        (, balance,, currentMP,,,) = stakeManager.accounts(address(userVault2));
+        assertEq(totalMP, stakeAmount + stakeAmount2, "account MP");
+        (, balance,, totalMP,,,) = stakeManager.accounts(address(userVault2));
         assertEq(balance, stakeAmount + stakeAmount2, "account 2 balance");
-        assertGt(currentMP, stakeAmount + stakeAmount2, "account 2 MP");
+        assertGt(totalMP, stakeAmount + stakeAmount2, "account 2 MP");
 
         vm.warp(stakeManager.epochEnd());
 
@@ -172,12 +172,12 @@ contract StakeTest is StakeManagerTest {
         vm.prank(testUser2);
         userVault2.stake(stakeAmount2, 0);
 
-        (, balance,, currentMP,,,) = stakeManager.accounts(address(userVault));
+        (, balance,, totalMP,,,) = stakeManager.accounts(address(userVault));
         assertEq(balance, stakeAmount + stakeAmount2 + stakeAmount2, "account balance 2");
-        assertGt(currentMP, stakeAmount + stakeAmount2 + stakeAmount2, "account MP 2");
-        (, balance,, currentMP,,,) = stakeManager.accounts(address(userVault2));
+        assertGt(totalMP, stakeAmount + stakeAmount2 + stakeAmount2, "account MP 2");
+        (, balance,, totalMP,,,) = stakeManager.accounts(address(userVault2));
         assertEq(balance, stakeAmount + stakeAmount2 + stakeAmount2, "account 2 balance 2");
-        assertGt(currentMP, stakeAmount + stakeAmount2 + stakeAmount2, "account 2 MP 2");
+        assertGt(totalMP, stakeAmount + stakeAmount2 + stakeAmount2, "account 2 MP 2");
     }
 
     function test_restakeJustLock() public {
@@ -191,12 +191,12 @@ contract StakeTest is StakeManagerTest {
         vm.prank(testUser2);
         userVault2.stake(0, lockToIncrease);
 
-        (, uint256 balance,, uint256 currentMP,,,) = stakeManager.accounts(address(userVault));
+        (, uint256 balance,, uint256 totalMP,,,) = stakeManager.accounts(address(userVault));
         assertEq(balance, stakeAmount, "account balance");
-        assertGt(currentMP, stakeAmount, "account MP");
-        (, balance,, currentMP,,,) = stakeManager.accounts(address(userVault2));
+        assertGt(totalMP, stakeAmount, "account MP");
+        (, balance,, totalMP,,,) = stakeManager.accounts(address(userVault2));
         assertEq(balance, stakeAmount, "account 2 balance");
-        assertGt(currentMP, stakeAmount, "account 2 MP");
+        assertGt(totalMP, stakeAmount, "account 2 MP");
 
         vm.warp(stakeManager.epochEnd());
 
@@ -205,12 +205,12 @@ contract StakeTest is StakeManagerTest {
         vm.prank(testUser2);
         userVault2.stake(0, lockToIncrease);
 
-        (, balance,, currentMP,,,) = stakeManager.accounts(address(userVault));
+        (, balance,, totalMP,,,) = stakeManager.accounts(address(userVault));
         assertEq(balance, stakeAmount, "account balance 2");
-        assertGt(currentMP, stakeAmount, "account MP 2");
-        (, balance,, currentMP,,,) = stakeManager.accounts(address(userVault2));
+        assertGt(totalMP, stakeAmount, "account MP 2");
+        (, balance,, totalMP,,,) = stakeManager.accounts(address(userVault2));
         assertEq(balance, stakeAmount, "account 2 balance 2");
-        assertGt(currentMP, stakeAmount, "account 2 MP 2");
+        assertGt(totalMP, stakeAmount, "account 2 MP 2");
     }
 
     function test_restakeStakeAndLock() public {
@@ -226,12 +226,12 @@ contract StakeTest is StakeManagerTest {
         vm.prank(testUser2);
         userVault2.stake(stakeAmount2, lockToIncrease);
 
-        (, uint256 balance,, uint256 currentMP,,,) = stakeManager.accounts(address(userVault));
+        (, uint256 balance,, uint256 totalMP,,,) = stakeManager.accounts(address(userVault));
         assertEq(balance, stakeAmount + stakeAmount2, "account balance");
-        assertGt(currentMP, stakeAmount + stakeAmount2, "account MP");
-        (, balance,, currentMP,,,) = stakeManager.accounts(address(userVault2));
+        assertGt(totalMP, stakeAmount + stakeAmount2, "account MP");
+        (, balance,, totalMP,,,) = stakeManager.accounts(address(userVault2));
         assertEq(balance, stakeAmount + stakeAmount2, "account 2 balance");
-        assertGt(currentMP, stakeAmount + stakeAmount2, "account 2 MP");
+        assertGt(totalMP, stakeAmount + stakeAmount2, "account 2 MP");
 
         vm.warp(stakeManager.epochEnd());
 
@@ -240,12 +240,12 @@ contract StakeTest is StakeManagerTest {
         vm.prank(testUser2);
         userVault2.stake(stakeAmount2, lockToIncrease);
 
-        (, balance,, currentMP,,,) = stakeManager.accounts(address(userVault));
+        (, balance,, totalMP,,,) = stakeManager.accounts(address(userVault));
         assertEq(balance, stakeAmount + stakeAmount2 + stakeAmount2, "account balance 2");
-        assertGt(currentMP, stakeAmount + stakeAmount2 + stakeAmount2, "account MP 2");
-        (, balance,, currentMP,,,) = stakeManager.accounts(address(userVault2));
+        assertGt(totalMP, stakeAmount + stakeAmount2 + stakeAmount2, "account MP 2");
+        (, balance,, totalMP,,,) = stakeManager.accounts(address(userVault2));
         assertEq(balance, stakeAmount + stakeAmount2 + stakeAmount2, "account 2 balance 2");
-        assertGt(currentMP, stakeAmount + stakeAmount2 + stakeAmount2, "account 2 MP 2");
+        assertGt(totalMP, stakeAmount + stakeAmount2 + stakeAmount2, "account 2 MP 2");
     }
 }
 
@@ -314,7 +314,7 @@ contract UnstakeTest is StakeManagerTest {
             vm.warp(stakeManager.epochEnd());
             stakeManager.executeAccount(address(userVault), i + 1);
         }
-        (, uint256 balanceBefore, uint256 initialMPBefore, uint256 currentMPBefore,,,) =
+        (, uint256 balanceBefore, uint256 bonusMPBefore, uint256 totalMPBefore,,,) =
             stakeManager.accounts(address(userVault));
         uint256 totalSupplyMPBefore = stakeManager.totalSupplyMP();
         uint256 unstakeAmount = stakeAmount * percentToBurn / 100;
@@ -322,7 +322,7 @@ contract UnstakeTest is StakeManagerTest {
 
         assertEq(ERC20(stakeToken).balanceOf(testUser), 0);
         userVault.unstake(unstakeAmount);
-        (, uint256 balanceAfter, uint256 initialMPAfter, uint256 currentMPAfter,,,) =
+        (, uint256 balanceAfter, uint256 bonusMPAfter, uint256 totalMPAfter,,,) =
             stakeManager.accounts(address(userVault));
 
         uint256 totalSupplyMPAfter = stakeManager.totalSupplyMP();
@@ -330,15 +330,15 @@ contract UnstakeTest is StakeManagerTest {
         console.log("totalSupplyMPAfter", totalSupplyMPAfter);
         console.log("balanceBefore", balanceBefore);
         console.log("balanceAfter", balanceAfter);
-        console.log("initialMPBefore", initialMPBefore);
-        console.log("initialMPAfter", initialMPAfter);
-        console.log("currentMPBefore", currentMPBefore);
-        console.log("currentMPAfter", currentMPAfter);
+        console.log("bonusMPBefore", bonusMPBefore);
+        console.log("bonusMPAfter", bonusMPAfter);
+        console.log("totalMPBefore", totalMPBefore);
+        console.log("totalMPAfter", totalMPAfter);
 
         assertEq(balanceAfter, balanceBefore - (balanceBefore * percentToBurn / 100));
-        assertEq(initialMPAfter, initialMPBefore - (initialMPBefore * percentToBurn / 100));
-        assertEq(currentMPAfter, currentMPBefore - (currentMPBefore * percentToBurn / 100));
-        assertEq(totalSupplyMPAfter, totalSupplyMPBefore - (currentMPBefore * percentToBurn / 100));
+        assertEq(bonusMPAfter, bonusMPBefore - (bonusMPBefore * percentToBurn / 100));
+        assertEq(totalMPAfter, totalMPBefore - (totalMPBefore * percentToBurn / 100));
+        assertEq(totalSupplyMPAfter, totalSupplyMPBefore - (totalMPBefore * percentToBurn / 100));
         assertEq(ERC20(stakeToken).balanceOf(testUser), unstakeAmount);
     }
 
@@ -364,11 +364,11 @@ contract LockTest is StakeManagerTest {
         vm.startPrank(testUser);
         userVault.lock(lockTime);
 
-        (, uint256 balance, uint256 initialMP, uint256 currentMP,,,) = stakeManager.accounts(address(userVault));
+        (, uint256 balance, uint256 bonusMP, uint256 totalMP,,,) = stakeManager.accounts(address(userVault));
 
         console.log("balance", balance);
-        console.log("initialMP", initialMP);
-        console.log("currentMP", currentMP);
+        console.log("bonusMP", bonusMP);
+        console.log("totalMP", totalMP);
     }
 
     function test_RevertWhen_InvalidNewLockupPeriod() public {
@@ -386,12 +386,12 @@ contract LockTest is StakeManagerTest {
 
         vm.warp(block.timestamp + stakeManager.MIN_LOCKUP_PERIOD() - 1);
         stakeManager.executeAccount(address(userVault), 1);
-        (, uint256 balance, uint256 initialMP, uint256 currentMP,, uint256 lockUntil,) =
+        (, uint256 balance, uint256 bonusMP, uint256 totalMP,, uint256 lockUntil,) =
             stakeManager.accounts(address(userVault));
 
         vm.startPrank(testUser);
         userVault.lock(minLockup - 1);
-        (, balance, initialMP, currentMP,, lockUntil,) = stakeManager.accounts(address(userVault));
+        (, balance, bonusMP, totalMP,, lockUntil,) = stakeManager.accounts(address(userVault));
 
         assertEq(lockUntil, block.timestamp + minLockup);
 
@@ -413,22 +413,21 @@ contract LockTest is StakeManagerTest {
         userVault.lock(minLockup - 1);
     }
 
-    function test_ShouldIncreaseInitialMP() public {
+    function test_ShouldIncreaseBonusMP() public {
         uint256 stakeAmount = 100;
         uint256 lockTime = stakeManager.MAX_LOCKUP_PERIOD();
         StakeVault userVault = _createStakingAccount(testUser, stakeAmount);
-        (, uint256 balance, uint256 initialMP, uint256 currentMP,,,) = stakeManager.accounts(address(userVault));
+        (, uint256 balance, uint256 bonusMP, uint256 totalMP,,,) = stakeManager.accounts(address(userVault));
         uint256 totalSupplyMPBefore = stakeManager.totalSupplyMP();
 
         vm.startPrank(testUser);
         userVault.lock(lockTime);
 
-        (, uint256 newBalance, uint256 newInitialMP, uint256 newCurrentMP,,,) =
-            stakeManager.accounts(address(userVault));
+        (, uint256 newBalance, uint256 newBonusMP, uint256 newCurrentMP,,,) = stakeManager.accounts(address(userVault));
         uint256 totalSupplyMPAfter = stakeManager.totalSupplyMP();
         assertGt(totalSupplyMPAfter, totalSupplyMPBefore, "totalSupplyMP");
-        assertGt(newInitialMP, initialMP, "initialMP");
-        assertGt(newCurrentMP, currentMP, "currentMP");
+        assertGt(newBonusMP, bonusMP, "bonusMP");
+        assertGt(newCurrentMP, totalMP, "totalMP");
         assertEq(newBalance, balance, "balance");
     }
 }
@@ -540,22 +539,21 @@ contract ExecuteAccountTest is StakeManagerTest {
             console.log("# PND_REWARDS", stakeManager.pendingReward());
 
             for (uint256 j = 0; j < userVaults.length; j++) {
-                (address rewardAddress,,, uint256 currentMPBefore, uint256 lastMintBefore,, uint256 epochBefore) =
+                (address rewardAddress,,, uint256 totalMPBefore, uint256 lastMintBefore,, uint256 epochBefore) =
                     stakeManager.accounts(address(userVaults[j]));
                 uint256 rewardsBefore = ERC20(stakeToken).balanceOf(rewardAddress);
                 console.log("-Vault number", j);
                 console.log("--=====BEFORE=====");
-                console.log("---### currentMP :", currentMPBefore);
+                console.log("---### totalMP :", totalMPBefore);
                 console.log("---#### lastMint :", lastMintBefore);
                 console.log("---## user_epoch :", epochBefore);
                 console.log("---##### rewards :", rewardsBefore);
                 console.log("--=====AFTER======");
                 stakeManager.executeAccount(address(userVaults[j]), epochBefore + 1);
-                (,,, uint256 currentMP, uint256 lastMint,, uint256 epoch) =
-                    stakeManager.accounts(address(userVaults[j]));
+                (,,, uint256 totalMP, uint256 lastMint,, uint256 epoch) = stakeManager.accounts(address(userVaults[j]));
                 uint256 rewards = ERC20(stakeToken).balanceOf(rewardAddress);
                 console.log("---### deltaTime :", lastMint - lastMintBefore);
-                console.log("---### currentMP :", currentMP);
+                console.log("---### totalMP :", totalMP);
                 console.log("---#### lastMint :", lastMint);
                 console.log("---## user_epoch :", epoch);
                 console.log("---##### rewards :", rewards);
@@ -564,11 +562,11 @@ contract ExecuteAccountTest is StakeManagerTest {
                 console.log("--# PND_REWARDS", stakeManager.pendingReward());
                 assertEq(lastMint, lastMintBefore + stakeManager.EPOCH_SIZE(), "must increaase lastMint");
                 assertEq(epoch, epochBefore + 1, "must increase epoch");
-                assertGt(currentMP, currentMPBefore, "must increase MPs");
+                assertGt(totalMP, totalMPBefore, "must increase MPs");
                 assertGt(rewards, rewardsBefore, "must increase rewards");
                 lastMintBefore = lastMint;
                 epochBefore = epoch;
-                currentMPBefore = currentMP;
+                totalMPBefore = totalMP;
             }
         }
     }
@@ -586,21 +584,20 @@ contract ExecuteAccountTest is StakeManagerTest {
             vm.warp(stakeManager.epochEnd());
             stakeManager.executeEpoch();
             for (uint256 j = 0; j < userVaults.length; j++) {
-                (address rewardAddress,,, uint256 currentMPBefore, uint256 lastMintBefore,, uint256 epochBefore) =
+                (address rewardAddress,,, uint256 totalMPBefore, uint256 lastMintBefore,, uint256 epochBefore) =
                     stakeManager.accounts(address(userVaults[j]));
                 uint256 rewardsBefore = ERC20(stakeToken).balanceOf(rewardAddress);
 
                 stakeManager.executeAccount(address(userVaults[j]), epochBefore + 1);
-                (,,, uint256 currentMP, uint256 lastMint,, uint256 epoch) =
-                    stakeManager.accounts(address(userVaults[j]));
+                (,,, uint256 totalMP, uint256 lastMint,, uint256 epoch) = stakeManager.accounts(address(userVaults[j]));
                 uint256 rewards = ERC20(stakeToken).balanceOf(rewardAddress);
                 assertEq(lastMint, lastMintBefore + stakeManager.EPOCH_SIZE(), "must increaase lastMint");
                 assertEq(epoch, epochBefore + 1, "must increase epoch");
-                assertGt(currentMP, currentMPBefore, "must increase MPs");
+                assertGt(totalMP, totalMPBefore, "must increase MPs");
                 assertGt(rewards, rewardsBefore, "must increase rewards");
                 lastMintBefore = lastMint;
                 epochBefore = epoch;
-                currentMPBefore = currentMP;
+                totalMPBefore = totalMP;
             }
         }
 
@@ -609,21 +606,20 @@ contract ExecuteAccountTest is StakeManagerTest {
             vm.warp(stakeManager.epochEnd());
             stakeManager.executeEpoch();
             for (uint256 j = 0; j < userVaults.length; j++) {
-                (address rewardAddress,,, uint256 currentMPBefore, uint256 lastMintBefore,, uint256 epochBefore) =
+                (address rewardAddress,,, uint256 totalMPBefore, uint256 lastMintBefore,, uint256 epochBefore) =
                     stakeManager.accounts(address(userVaults[j]));
                 uint256 rewardsBefore = ERC20(stakeToken).balanceOf(rewardAddress);
 
                 stakeManager.executeAccount(address(userVaults[j]), epochBefore + 1);
-                (,,, uint256 currentMP, uint256 lastMint,, uint256 epoch) =
-                    stakeManager.accounts(address(userVaults[j]));
+                (,,, uint256 totalMP, uint256 lastMint,, uint256 epoch) = stakeManager.accounts(address(userVaults[j]));
                 uint256 rewards = ERC20(stakeToken).balanceOf(rewardAddress);
                 assertEq(lastMint, lastMintBefore + stakeManager.EPOCH_SIZE(), "must increaase lastMint");
                 assertEq(epoch, epochBefore + 1, "must increase epoch");
-                assertEq(currentMP, currentMPBefore, "must NOT increase MPs");
+                assertEq(totalMP, totalMPBefore, "must NOT increase MPs");
                 assertGt(rewards, rewardsBefore, "must increase rewards");
                 lastMintBefore = lastMint;
                 epochBefore = epoch;
-                currentMPBefore = currentMP;
+                totalMPBefore = totalMP;
             }
         }
     }


### PR DESCRIPTION
After discussing this offline, we've decided that the naming of these properties was misleading. This commit performs the following changes:

- `account.initialMP` becomes `account.bonusMP`
- `account.currentMP` becomes `account.totalMP`

Rationale:

`initialMP` indicates that this is an immutable field which is not the case as in scenarios where accounts increase the `lock()` time, they'll also increase their bonus multiplier (`initialMP`).

`currentMP` was misleading in combination with `initialMP`. Really what it reflects is the total multiplier points of an account **including** its bonus multiplier points.


## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [ ] Ran `pnpm gas-report`?
- [x] Ran `pnpm lint`?
- [x] Ran `forge test`?
- [x] Ran `pnpm verify`?
