### PR TITLE
chore(ci): update certora CLI in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
         with: { java-version: "11", java-package: jre }
 
       - name: Install Certora CLI
-        run: pip3 install certora-cli==7.0.7
+        run: pip3 install certora-cli==7.10.1
 
       - name: Install Solidity
         run: |


### PR DESCRIPTION
This update the certora cli to the latest version 7.10.1 in CI tasks.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [ ] Ran `pnpm gas-report`?
- [ ] Ran `pnpm lint`?
- [ ] Ran `forge test`?
- [x] Ran `pnpm verify`?
